### PR TITLE
Add dream image uploads

### DIFF
--- a/supabase/functions/stitch_panels/index.ts
+++ b/supabase/functions/stitch_panels/index.ts
@@ -37,12 +37,19 @@ serve(async (req) => {
       return new Response("Invalid JSON", { status: 400 });
     }
 
-    const urls = (body as { urls?: unknown }).urls;
+    const { urls, userId, dreamId } = body as {
+      urls?: unknown;
+      userId?: unknown;
+      dreamId?: unknown;
+    };
     if (!Array.isArray(urls) || urls.length < 4 || urls.length > 6) {
       return new Response(
         "Expected JSON body with 'urls' array of 4 to 6 image URLs",
         { status: 400 }
       );
+    }
+    if (typeof userId !== "string" || typeof dreamId !== "string") {
+      return new Response("Missing userId or dreamId", { status: 400 });
     }
 
     // Load and decode each image via canvas
@@ -86,7 +93,7 @@ serve(async (req) => {
     const finalBuffer = canvas.toBuffer();
 
     // Upload to Supabase Storage
-    const path = `stitched/${crypto.randomUUID()}.png`;
+    const path = `${userId}/${dreamId}/composite.png`;
     const { error } = await supabase.storage
       .from("comics")
       .upload(path, finalBuffer, { upsert: true, contentType: "image/png" });
@@ -97,7 +104,7 @@ serve(async (req) => {
 
     // Return public URL
     const { data: pub } = supabase.storage.from("comics").getPublicUrl(path);
-    return new Response(JSON.stringify({ url: pub.publicUrl }), {
+    return new Response(JSON.stringify({ path, url: pub.publicUrl }), {
       status: 200,
       headers: { "Content-Type": "application/json" },
     });


### PR DESCRIPTION
## Summary
- store dream images in Supabase storage
- stitch panels into a composite image in user folder
- save paths in the `dreams` table

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6854525d4914832fb52b5af46dc6b5e0